### PR TITLE
Fix: Add reference to redis service in scalelite-recording-importer container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
     env_file:
       - .env
     environment:
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
       - DATABASE_URL=${DATABASE_URL:-postgres://postgres:password@postgres:5432/scalelite?pool=5}
       - RECORDING_DISABLED=false
       - RAILS_LOG_TO_STDOUT=${RAILS_LOG_TO_STDOUT:-false}


### PR DESCRIPTION

This is necessary to work with multi-tenancy and meta_bbb-recording-ready-url